### PR TITLE
Expose postgres ports in dev docker compose

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -14,6 +14,8 @@ services:
 
   postgres:
     image: postgres:16
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres


### PR DESCRIPTION
So one can use docker-compose-dev to only spin up the db when working on the backend