### PR TITLE
[WIP] Refactor login mechanism to allow for multiple roles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against Svelte dev server",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}/frontend-svelte",
+      "sourceMapPathOverrides": {
+        "/__file:///*": "${webRoot}/*"
+      },
+      "preLaunchTask": "start-svelte-dev-server",
+      "skipFiles": [
+        "<node_internals>/**"
+      ]
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "start-svelte-dev-server",
+      "type": "shell",
+      "command": "cd frontend-svelte && npm run dev",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "svelte",
+        "pattern": {
+          "regexp": "^.*$",
+          "file": 1,
+          "location": 2,
+          "message": 3
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".*server is running.*",
+          "endsPattern": ".*ready in.*"
+        }
+      }
+    }
+  ]
+}

--- a/frontend-svelte/src/lib/api/auth.ts
+++ b/frontend-svelte/src/lib/api/auth.ts
@@ -84,6 +84,7 @@ export async function loginWebauthn(username: string) {
 	).then(mapError);
 
 	console.log('res', res);
+	return res;
 }
 
 export async function logout() {

--- a/frontend-svelte/src/lib/api/users.ts
+++ b/frontend-svelte/src/lib/api/users.ts
@@ -18,6 +18,13 @@ export async function getAllUsers(fetch: FetchFunction): Promise<User[]> {
 	return res.json();
 }
 
+export async function getAllLimitedUsers(fetch: FetchFunction): Promise<User[]> {
+	console.debug('getAllLimitedUsers...');
+	const res = await fetch(`${baseUrl}/user/limited`, { credentials: 'include' })
+		.then(mapError);
+	return res.json();
+}
+
 export async function getUserById(fetch: FetchFunction, id: string): Promise<User> {
 	console.debug(`getUserById(${id})`);
 	const res = await fetch(`${baseUrl}/user/${id}`, { credentials: 'include' })

--- a/frontend-svelte/src/routes/+layout.ts
+++ b/frontend-svelte/src/routes/+layout.ts
@@ -8,8 +8,8 @@ export const ssr = true;
 
 export const load: LayoutLoad = async ({ fetch }) => {
 	try {
-		const me = await getMe(fetch);
-		return { me };
+		const mePromise = getMe(fetch);
+		return { mePromise };
 	} catch (error) {
 		return { me: null, error };
 	}

--- a/frontend-svelte/src/routes/+layout.ts
+++ b/frontend-svelte/src/routes/+layout.ts
@@ -1,1 +1,16 @@
+import type { LayoutLoad } from './$types';
+import { base } from '$app/paths';
+import { getMe } from '$lib/api/users';
+import { redirect } from '@sveltejs/kit';
+import { UNAUTHORIZED_ERROR } from '$lib/api/model/error';
+
 export const ssr = true;
+
+export const load: LayoutLoad = async ({ fetch }) => {
+	try {
+		const me = await getMe(fetch);
+		return { me };
+	} catch (error) {
+		return { me: null, error };
+	}
+};

--- a/frontend-svelte/src/routes/+page.svelte
+++ b/frontend-svelte/src/routes/+page.svelte
@@ -8,10 +8,12 @@
 
   let { data } = $props();
 
-  onMount(() => {
+  onMount(async ()  => {
+		// Wait for me data to be loaded by the server
+		const me = await data.mePromise;
 		// Handle redirection based on user type
-		if (data.me) {
-			if (data.me.isAdmin) {
+		if (me) {
+			if (me.isAdmin) {
 				goto(`${base}/admin`);
 			} else {
 				goto(`${base}/instructor`);

--- a/frontend-svelte/src/routes/+page.svelte
+++ b/frontend-svelte/src/routes/+page.svelte
@@ -1,16 +1,45 @@
 <script>
 	import { base } from '$app/paths';
 	import { Button } from '$lib/components/ui/button/';
+    import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
 
   console.log(`base is ${base}`)
+
+  let { data } = $props();
+
+  onMount(() => {
+		// Handle redirection based on user type
+		if (data.me) {
+			if (data.me.isAdmin) {
+				goto(`${base}/admin`);
+			} else {
+				goto(`${base}/instructor`);
+			}
+		} else {
+			// No user data means not logged in
+			goto(`${base}/login`);
+		}
+	});
 </script>
 
-<div class="container">
-	<h1 class="font-accent italic text-5xl my-4">fabX</h1>
-	<h2 class="font-accent text-2xl my-2">Access System for Makerspaces</h2>
+<svelte:head>
+	<title>fabX | Loading</title>
+</svelte:head>
 
-	<div class="flex flex-col my-4">
-		<Button class="my-4 p-8" href="{base}/admin">Admin</Button>
-		<Button class="my-4 p-8 bg-gray-800 hover:bg-gray-700" href="https://github.com/fabXlabs/fabX" target="_blank" rel="noopener noreferrer">GitHub</Button>
+ <!-- TOOD: Add a skeleton here -->
+<!-- Skeleton loader while redirecting -->
+<!-- <div class="container flex items-center justify-center min-h-screen">
+	<div class="w-full max-w-md space-y-8">
+		<div class="flex flex-col items-center">
+			<Skeleton class="h-12 w-48 mb-4" />
+			<Skeleton class="h-6 w-72" />
+		</div>
+
+		<div class="space-y-4 mt-8">
+			<Skeleton class="h-16 w-full" />
+			<Skeleton class="h-16 w-full" />
+			<Skeleton class="h-16 w-full" />
+		</div>
 	</div>
-</div>
+</div> -->

--- a/frontend-svelte/src/routes/instructor/+layout.ts
+++ b/frontend-svelte/src/routes/instructor/+layout.ts
@@ -13,5 +13,5 @@ export const load: LayoutLoad = async ({ fetch }) => {
 			redirect(302, `${base}/login`);
 		}
 	}
-	throw Error('Runtime exception during loading admin layout. Should never reach.');
+	throw Error('Runtime exception during loading instructor layout. Should never reach.');
 };

--- a/frontend-svelte/src/routes/instructor/+page.svelte
+++ b/frontend-svelte/src/routes/instructor/+page.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	// noinspection ES6UnusedImports
+	import * as Card from '$lib/components/ui/card/index.js';
+	import { base } from '$app/paths';
+	import type { PageProps } from './$types';
+	import { Drill, Microchip, Stamp, Users } from 'lucide-svelte';
+
+	let { data }: PageProps = $props();
+</script>
+
+<svelte:head>
+	<title>fabX | Instructor</title>
+</svelte:head>
+
+
+<div class="container relative max-w-(--breakpoint-2xl) mt-7">
+	<h2 class="font-accent text-2xl my-2">Hello, {data.me?.firstName}</h2>
+</div>
+

--- a/frontend-svelte/src/routes/instructor/+page.ts
+++ b/frontend-svelte/src/routes/instructor/+page.ts
@@ -1,0 +1,10 @@
+import type { PageLoad } from './$types';
+import { getAllLimitedUsers } from '$lib/api/users';
+
+export const load: PageLoad = async ({ fetch, params }) => {
+	const limitedUsersData_ = getAllLimitedUsers(fetch).catch(_ => { return []; });
+
+	return {
+		users: await limitedUsersData_
+	};
+};

--- a/frontend-svelte/src/routes/login/+page.svelte
+++ b/frontend-svelte/src/routes/login/+page.svelte
@@ -24,7 +24,7 @@
 	async function loginPasswordless() {
 		await loginWebauthn(username)
 			.then(() => {
-				goto(`${base}/admin`);
+				goto(`${base}`);
 			})
 			.catch(e => { error = e; });
 	}
@@ -36,7 +36,7 @@
 		} else {
 			await loginBasicAuth(username, password)
 				.then(() => {
-					goto(`${base}/admin`);
+					goto(`${base}`);
 				})
 				.catch(e => { error = e; });
 		}

--- a/frontend-svelte/src/routes/logout/+page.svelte
+++ b/frontend-svelte/src/routes/logout/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { goto } from '$app/navigation';
 	import { logout } from '$lib/api/auth';
 
 	async function doLogout() {
 		const res = await logout();
 		console.debug("logout", res);
+		goto('/');
 	}
 </script>
 


### PR DESCRIPTION
This PR is a proposition on how to restructure the login page to allow for multiple roles.

## Description
- Adds vscode debugging settings for svelte frontend
- Restructure login so that:
** A logged out user accessing / gets redirected to /login
** A logged in user gets redirected to /admin or /instructor based on user profile data

## ToDos
- See TODO comments in code
- Split up PR to be in atomic units if proposition is accepted