### PR TITLE
Fix vite proxy port to align with docker compose setup

### DIFF
--- a/frontend-svelte/vite.config.ts
+++ b/frontend-svelte/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
 	plugins: [sveltekit()],
 	server: {
 		proxy: {
-			'/api': 'http://localhost:8080',
+			'/api': 'http://localhost:8000',
 		}
 	}
 });


### PR DESCRIPTION
## Description

- Fix vite proxy port to align with docker compose setup

Docker compose setup uses port 8000, not 8080